### PR TITLE
docs: Added hostname to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import Sitemap from 'vite-plugin-sitemap'
 export default {
   plugins: [
     Vue(),
-    Sitemap(),
+    Sitemap({ hostname: 'https://example.com' }),
   ],
 }
 ```


### PR DESCRIPTION
Make it clear in the example code that, at minimum, a hostname must be supplied.