### PR TITLE
chore: add package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "version": "0.8.2",
   "packageManager": "pnpm@9.1.2",
   "description": "Sitemap generator plugin for Vite",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jbaubree/vite-plugin-sitemap.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jbaubree/vite-plugin-sitemap/issues"
+  },
+  "homepage": "https://github.com/jbaubree/vite-plugin-sitemap#readme",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Adds missing package metadata to `package.json`:

- `license`: MIT, matching the repository license
- `repository`: GitHub repository URL
- `bugs`: GitHub issue tracker URL
- `homepage`: README URL

## Why

The published `vite-plugin-sitemap@0.8.2` npm metadata currently only exposes `name` and `version` for these fields, so npm clients do not show the repository, issue tracker, homepage, or machine-readable license.

## Validation

- `npm view vite-plugin-sitemap@0.8.2 name version repository homepage bugs license --json`
- local `package.json` assertion for `license`, `repository.url`, `bugs.url`, and `homepage`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check` (only Windows LF/CRLF warning locally)
